### PR TITLE
Removes email from the faculty model since it's already contained in …

### DIFF
--- a/app/models/faculty.rb
+++ b/app/models/faculty.rb
@@ -2,5 +2,5 @@ class Faculty < ApplicationRecord
   belongs_to :user
   has_and_belongs_to_many :projects, join_table: "project_faculties"
   validates :department, presence: true, length: { maximum: 255 } # Presence and max length for department
-  validates :email, presence: true, length: { maximum: 255 } # Presence and max length for emailend
+  # validates :email, presence: true, length: { maximum: 255 } # Presence and max length for emailend
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   has_one :admin, dependent: :destroy
 
   # Add validations, even though we use OAuth.
-  validates :email, presence: true, uniqueness: { case_sensitive: false }
+  validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
   validates :name, presence: true
   validates :uid, presence: true
   validates :provider, presence: true


### PR DESCRIPTION
…the user model. Limits the length  in the user model.

Logins seemed a little borked for faculty since an email field is included in their model. I removed this from their model and moved it to the user model, including field maximums along the way.